### PR TITLE
Feature/jwt builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,29 @@
 
+SHELL := /bin/bash
+JQ    := $(shell which jq >/dev/null && echo jq || echo cat)
+
+.PHONY: test
 test:
 	go test -v ./...
+
+.PHONY: demo
+demo:
+	go run cmd/jwt-builder/*.go \
+		--user_id 99 \
+		--identity_user_id user.guid99 \
+		--account_id 42 \
+		--identity_account_id account.guid42 \
+		--service petstore \
+		--groups estaff,managers \
+		--subject_id cto@petstore.swagger.io \
+		--subject_type user \
+		--subject_auth_id abcdef \
+		--subject_auth_type token \
+		--audience all \
+		--expires 24h \
+		--issuer token \
+		--hmac_key swordfish1 \
+		| tee -a /dev/stderr \
+		| cut -f2 -d. | base64 -D \
+		| awk '/}$$/{print;exit 0} {print $$0 "}"}' | $(JQ)
+

--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,68 @@
+package atlas_claims
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+const (
+	STKAudience = "ib-stk"
+
+	DefaultIssuer          = "atlas-claims"
+	DefaultAudience        = STKAudience
+	DefaultService         = "all"
+	DefaultSubjectType     = "s2s"
+	DefaultSubjectAuthType = "bearer"
+)
+
+func BuildJwt(claims *Claims, hmacKey string, expires_duration time.Duration) (string, error) {
+	if len(strings.TrimSpace(hmacKey)) < 1 {
+		return "", fmt.Errorf("non-empty hmac key is required")
+	}
+
+	// standard claims
+	if claims.Issuer == "" {
+		claims.Issuer = DefaultIssuer
+	}
+	if claims.Audience == "" {
+		claims.Audience = DefaultAudience
+	}
+	if claims.IssuedAt == 0 {
+		claims.IssuedAt = time.Now().Unix()
+	}
+	if claims.NotBefore == 0 {
+		claims.NotBefore = claims.IssuedAt
+	}
+	if claims.ExpiresAt == 0 {
+		claims.ExpiresAt = time.Unix(claims.IssuedAt, 0).Add(expires_duration).Unix()
+	}
+
+	// non-standard claims
+	if claims.AccountId == "" && claims.Audience != STKAudience {
+		claims.AccountId = "0"
+	}
+	if claims.Service == "" {
+		claims.Service = DefaultService
+	}
+	if claims.Subject.Id == "" {
+		claims.Subject.Id = fmt.Sprintf("service.%s.%d", claims.Service, claims.IssuedAt)
+	}
+	if claims.Subject.SubjectType == "" {
+		claims.Subject.SubjectType = DefaultSubjectType
+	}
+	if claims.Subject.AuthenticationType == "" {
+		claims.Subject.AuthenticationType = DefaultSubjectAuthType
+	}
+
+	// sign the jwt
+	token := jwt.NewWithClaims(jwt.SigningMethodHS512, claims)
+	tokenString, err := token.SignedString([]byte(hmacKey))
+	if err != nil {
+		return "", fmt.Errorf("failed to sign claim: %v", err)
+	}
+
+	return tokenString, nil
+}

--- a/claims.go
+++ b/claims.go
@@ -8,8 +8,8 @@ import (
 type Subject struct {
 	Id                 string `json:"id,omitempty"`                // user_email if authentication_type=(user_jwt|api_key)
 	SubjectType        string `json:"subject_type"`                //valid values: user/s2s
-	AuthenticationType string `json:"authentication_type"`         //valid values: bearer/token
 	AuthenticationId   string `json:"authentication_id,omitempty"` // the id of the api_key if authentication_type=token
+	AuthenticationType string `json:"authentication_type"`         //valid values: bearer/token
 }
 
 // Claims models the claims that atlas authz cares about.

--- a/cmd/jwt-builder/main.go
+++ b/cmd/jwt-builder/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	atlas_claims "github.com/infobloxopen/atlas-claims"
+)
+
+const (
+	s2s_audience = "ib-stk"
+)
+
+var (
+	// default claims
+	cfgUserId                 = ""
+	cfgIdentityUserId         = ""
+	cfgAccountId              = ""
+	cfgIdentityAccountId      = ""
+	cfgService                = atlas_claims.DefaultService
+	strGroups                 = ""
+	cfgSubjectId              = ""
+	cfgSubjectType            = atlas_claims.DefaultSubjectType
+	cfgSubjectAuthId          = ""
+	cfgSubjectAuthType        = ""
+	cfgStandardClaimsAudience = atlas_claims.DefaultAudience
+	cfgStandardClaimsExpires  = time.Duration(time.Hour * 24 * 365).String()
+	cfgStandardClaimsIssuer   = atlas_claims.DefaultIssuer
+	cfgHmacKey                = "swordfish"
+)
+
+func main() {
+	// define flag overrides
+	flag.StringVar(&cfgUserId, "user_id", cfgUserId, "user id")
+	flag.StringVar(&cfgIdentityUserId, "identity_user_id", cfgIdentityUserId, "identity user id")
+	flag.StringVar(&cfgAccountId, "account_id", cfgAccountId, "account id (int)")
+	flag.StringVar(&cfgIdentityAccountId, "identity_account_id", cfgIdentityAccountId, "identity account id (guid)")
+	flag.StringVar(&cfgService, "service", cfgService, "service")
+	flag.StringVar(&strGroups, "groups", strGroups, "groups (comma separated list)")
+	flag.StringVar(&cfgSubjectId, "subject_id", cfgSubjectId, "subject id")
+	flag.StringVar(&cfgSubjectType, "subject_type", cfgSubjectType, "subject type")
+	flag.StringVar(&cfgSubjectAuthId, "subject_auth_id", cfgSubjectAuthId, "subject authentication id")
+	flag.StringVar(&cfgSubjectAuthType, "subject_auth_type", cfgSubjectAuthType, "subject authentication type")
+	flag.StringVar(&cfgStandardClaimsAudience, "audience", cfgStandardClaimsAudience, "audience")
+	flag.StringVar(&cfgStandardClaimsExpires, "expires", cfgStandardClaimsExpires, "expires duration, i.e. 48h")
+	flag.StringVar(&cfgStandardClaimsIssuer, "issuer", cfgStandardClaimsIssuer, "issuer")
+	flag.StringVar(&cfgHmacKey, "hmac_key", cfgHmacKey, "default hmac key")
+	flag.Parse()
+
+	// define claims from cli
+	cfgGroups := strings.Split(strGroups, ",")
+	claims := &atlas_claims.Claims{
+		UserId:            cfgUserId,
+		IdentityUserId:    cfgIdentityUserId,
+		AccountId:         cfgAccountId,
+		IdentityAccountId: cfgIdentityAccountId,
+		Service:           cfgService,
+		Groups:            cfgGroups,
+		Subject: atlas_claims.Subject{
+			Id:                 cfgSubjectId,
+			SubjectType:        cfgSubjectType,
+			AuthenticationId:   cfgSubjectAuthId,
+			AuthenticationType: cfgSubjectType,
+		},
+		StandardClaims: jwt.StandardClaims{
+			Audience: cfgStandardClaimsAudience,
+			Issuer:   cfgStandardClaimsIssuer,
+		},
+	}
+
+	// parse expires
+	dur, err := time.ParseDuration(cfgStandardClaimsExpires)
+	if err != nil {
+		log.Fatalf("failed to parse expires duration: %s", err)
+	}
+
+	// build jwt
+	tokenString, err := atlas_claims.BuildJwt(claims, cfgHmacKey, dur)
+	if err != nil {
+		log.Fatalf("failed to build jwt due to error: %s", err)
+	}
+
+	// print jwt
+	fmt.Printf("%v\n", tokenString)
+}


### PR DESCRIPTION
### DEMO:
```
# wlu@rm-ml-wlu: make demo
go run cmd/jwt-builder/*.go \
		--user_id 99 \
		--identity_user_id user.guid99 \
		--account_id 42 \
		--identity_account_id account.guid42 \
		--service petstore \
		--groups estaff,managers \
		--subject_id cto@petstore.swagger.io \
		--subject_type user \
		--subject_auth_id abcdef \
		--subject_auth_type token \
		--audience all \
		--expires 24h \
		--issuer token \
		--hmac_key swordfish1 \
		| tee -a /dev/stderr \
		| cut -f2 -d. | base64 -D \
		| awk '/}$/{print;exit 0} {print $0 "}"}' | jq
eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiOTkiLCJpZGVudGl0eV91c2VyX2lkIjoidXNlci5ndWlkOTkiLCJhY2NvdW50X2lkIjoiNDIiLCJpZGVudGl0eV9hY2NvdW50X2lkIjoiYWNjb3VudC5ndWlkNDIiLCJzZXJ2aWNlIjoicGV0c3RvcmUiLCJncm91cHMiOlsiZXN0YWZmIiwibWFuYWdlcnMiXSwic3ViamVjdCI6eyJpZCI6ImN0b0BwZXRzdG9yZS5zd2FnZ2VyLmlvIiwic3ViamVjdF90eXBlIjoidXNlciIsImF1dGhlbnRpY2F0aW9uX2lkIjoiYWJjZGVmIiwiYXV0aGVudGljYXRpb25fdHlwZSI6InVzZXIifSwiYXVkIjoiYWxsIiwiZXhwIjoxNjA4MjYyMjA3LCJpYXQiOjE2MDgxNzU4MDcsImlzcyI6InRva2VuIiwibmJmIjoxNjA4MTc1ODA3fQ.0lwFSJNEdDu_FiP3-_aDg8gM0N0AmTPO5AvpTuIQRhebV8wh7cVrQZxPfnDKWSoWYZEsrMsGut9puom6mz0e_w
{
  "user_id": "99",
  "identity_user_id": "user.guid99",
  "account_id": "42",
  "identity_account_id": "account.guid42",
  "service": "petstore",
  "groups": [
    "estaff",
    "managers"
  ],
  "subject": {
    "id": "cto@petstore.swagger.io",
    "subject_type": "user",
    "authentication_id": "abcdef",
    "authentication_type": "user"
  },
  "aud": "all",
  "exp": 1608262207,
  "iat": 1608175807,
  "iss": "token",
  "nbf": 1608175807
}

```